### PR TITLE
refactor: migrate pre-commit hooks to use just commands

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,33 +16,33 @@ repos:
 
   - repo: local
     hooks:
-      - id: ruff-format
-        name: ruff format
-        entry: cd backend && uv run ruff format
+      - id: fmt-backend
+        name: just fmt-backend
+        entry: just fmt-backend
         language: system
         types: [python]
         pass_filenames: false
         always_run: true
 
-      - id: ruff-check
-        name: ruff check
-        entry: cd backend && uv run ruff check --fix
+      - id: lint-backend
+        name: just lint-backend
+        entry: just lint-backend
         language: system
         types: [python]
         pass_filenames: false
         always_run: true
 
-      - id: pyright
-        name: pyright
-        entry: cd backend && uv run pyright
+      - id: typecheck-backend
+        name: just typecheck-backend
+        entry: just typecheck-backend
         language: system
         types: [python]
         pass_filenames: false
         always_run: true
 
-      - id: pytest
-        name: pytest
-        entry: cd backend && uv run pytest test
+      - id: test-backend
+        name: just test-backend
+        entry: just test-backend
         language: system
         types: [python]
         pass_filenames: false

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -81,10 +81,9 @@ reportUnusedImport = true
 reportUnusedVariable = true
 stubPath = "stubs"
 extraPaths = ["src"]
-typeCheckingMode = "basic"
+typeCheckingMode = "standard"
 venvPath = ".venv"
 venvName = ".venv"
-ignore = ["**/channels/**"]
 
 [tool.django-stubs]
 django_settings_module = "project.settings"


### PR DESCRIPTION
- Replace direct tool invocations with just commands in pre-commit hooks
- Update pyright configuration to use standard type checking mode
- Remove unnecessary ignore patterns from pyright config